### PR TITLE
Enable stock status update and add check for outofstock option

### DIFF
--- a/wp-content/plugins/duellintegration/duellintegration.php
+++ b/wp-content/plugins/duellintegration/duellintegration.php
@@ -1983,10 +1983,13 @@ class Duellintegration {
                         $currentStock = get_post_meta($post_id, '_stock', true);
                         write_log('processStockUpdation() Before updating stock - Product Id: ' . $post_id . ' Current Status: ' . $stockStatus . ' Current Qty: ' . $currentStock . ' New Qty: ' . $stock, true);
                         $stockStatusMsg = 'onbackorder';
-                        if ($stock > 0) {
+                        if ($stock == 0) {
+                            $stockStatusMsg = 'outofstock';
+                        }
+                        elseif ($stock > 0) {
                             $stockStatusMsg = 'instock';
                         }
-                        //update_post_meta($post_id, '_stock_status', $stockStatusMsg);
+                        update_post_meta($post_id, '_stock_status', $stockStatusMsg);
                         update_post_meta($post_id, '_stock', $stock);
                     }
                 }


### PR DESCRIPTION
Hi
We experienced some issues with the stock status not updating after a product was sold on Duell. This change seemed to fix the issue for us.